### PR TITLE
Consolidate on one commit splitting implementation

### DIFF
--- a/gitbutler-ui/src/lib/backend/aiService.ts
+++ b/gitbutler-ui/src/lib/backend/aiService.ts
@@ -1,11 +1,12 @@
 import { AnthropicAIClient } from '$lib/backend/aiClients/anthropic';
 import { ButlerAIClient } from '$lib/backend/aiClients/butler';
 import { OpenAIClient } from '$lib/backend/aiClients/openAI';
+import { splitMessage } from '$lib/utils/commitMessage';
 import * as toasts from '$lib/utils/toasts';
 import OpenAI from 'openai';
-import type { AIClient } from './aiClient';
-import type { getCloudApiClient } from './cloud';
-import type { GitConfigService } from './gitConfigService';
+import type { AIClient } from '$lib/backend/aiClient';
+import type { getCloudApiClient } from '$lib/backend/cloud';
+import type { GitConfigService } from '$lib/backend/gitConfigService';
 
 const diffLengthLimit = 20000;
 
@@ -209,8 +210,8 @@ export class AIService {
 			message = message.split('\n')[0];
 		}
 
-		const [summary, description] = message.split(/\n+(.*)/s);
-		return description ? `${summary}\n\n${description}` : summary;
+		const { title, description } = splitMessage(message);
+		return description ? `${title}\n\n${description}` : title;
 	}
 
 	async summarizeBranch({

--- a/gitbutler-ui/src/lib/components/CommitDialog.svelte
+++ b/gitbutler-ui/src/lib/components/CommitDialog.svelte
@@ -14,6 +14,7 @@
 		projectRunCommitHooks,
 		persistedCommitMessage
 	} from '$lib/config/config';
+	import { splitMessage } from '$lib/utils/commitMessage';
 	import { getContextByClass } from '$lib/utils/context';
 	import * as toasts from '$lib/utils/toasts';
 	import { tooltip } from '$lib/utils/tooltip';
@@ -56,13 +57,8 @@
 	let titleTextArea: HTMLTextAreaElement;
 	let descriptionTextArea: HTMLTextAreaElement;
 
-	$: [title, description] = splitMessage($commitMessage);
+	$: ({ title, description } = splitMessage($commitMessage));
 	$: if ($commitMessage) updateHeights();
-
-	function splitMessage(message: string) {
-		const parts = message.split(/\n+(.*)/s);
-		return [parts[0] || '', parts[1] || ''];
-	}
 
 	function concatMessage(title: string, description: string) {
 		return `${title}\n\n${description}`;

--- a/gitbutler-ui/src/lib/utils/commitMessage.test.ts
+++ b/gitbutler-ui/src/lib/utils/commitMessage.test.ts
@@ -1,0 +1,60 @@
+import { splitMessage } from '$lib/utils/commitMessage';
+import { expect, test, describe } from 'vitest';
+
+describe.concurrent('#splitMessage', () => {
+	test('When provided an empty string, it returns an empty title and description', () => {
+		expect(splitMessage('')).toMatchObject({ title: '', description: '' });
+	});
+
+	test('When provided a single line, it returns a title and empty description', () => {
+		const message = 'Fixed all the bugs!';
+
+		expect(splitMessage(message)).toMatchObject({ title: 'Fixed all the bugs!', description: '' });
+	});
+
+	test('When provided a commit message with one newline, it returns a title and description', () => {
+		const message = 'Fixed all the bugs!\nActually maybe not...';
+
+		expect(splitMessage(message)).toMatchObject({
+			title: 'Fixed all the bugs!',
+			description: 'Actually maybe not...'
+		});
+	});
+
+	test('When provided a commit message with multiple newline, it returns a title and description', () => {
+		const message = 'Fixed all the bugs!\n\nActually maybe not...';
+
+		expect(splitMessage(message)).toMatchObject({
+			title: 'Fixed all the bugs!',
+			description: 'Actually maybe not...'
+		});
+
+		const message2 = 'Fixed all the bugs!\n\n\n\nActually maybe not...';
+
+		expect(splitMessage(message2)).toMatchObject({
+			title: 'Fixed all the bugs!',
+			description: 'Actually maybe not...'
+		});
+	});
+
+	test('When proivded a commit message with newlines in the description, it returns a title and description', () => {
+		const message = `Fixed all the bugs!
+
+Broke something else
+
+Made it better
+Got a dog
+
+I fancy coffee`;
+
+		const title = 'Fixed all the bugs!';
+		const description = `Broke something else
+
+Made it better
+Got a dog
+
+I fancy coffee`;
+
+		expect(splitMessage(message)).toMatchObject({ title, description });
+	});
+});

--- a/gitbutler-ui/src/lib/utils/commitMessage.ts
+++ b/gitbutler-ui/src/lib/utils/commitMessage.ts
@@ -1,0 +1,10 @@
+const commitMessageSplitRegExp = /(.*?)(?:\n+|$)(.*)/s;
+
+export function splitMessage(message: string) {
+	const matches = message.match(commitMessageSplitRegExp);
+
+	return {
+		title: matches?.[1] || '',
+		description: matches?.[2] || ''
+	};
+}

--- a/gitbutler-ui/src/lib/vbranches/types.ts
+++ b/gitbutler-ui/src/lib/vbranches/types.ts
@@ -1,4 +1,5 @@
 import 'reflect-metadata';
+import { splitMessage } from '$lib/utils/commitMessage';
 import { hashCode } from '$lib/utils/string';
 import { Type, Transform } from 'class-transformer';
 
@@ -131,26 +132,15 @@ export class Commit {
 	}
 
 	get descriptionTitle(): string | undefined {
-		return this.descriptionLines[0];
+		return splitMessage(this.description).title || undefined;
 	}
 
 	get descriptionBody(): string | undefined {
-		let sliceCount = 1;
-
-		// Remove a blank first line
-		if (this.descriptionLines[1] == '') {
-			sliceCount = 2;
-		}
-
-		return this.descriptionLines.slice(sliceCount).join('\n');
+		return splitMessage(this.description).description || undefined;
 	}
 
 	isParentOf(possibleChild: Commit) {
 		return possibleChild.parentIds.includes(this.id);
-	}
-
-	private get descriptionLines() {
-		return this.description.split('\n');
 	}
 }
 
@@ -166,22 +156,11 @@ export class RemoteCommit {
 	}
 
 	get descriptionTitle(): string | undefined {
-		return this.descriptionLines[0];
+		return splitMessage(this.description).title || undefined;
 	}
 
 	get descriptionBody(): string | undefined {
-		let sliceCount = 1;
-
-		// Remove a blank first line
-		if (this.descriptionLines[1] == '') {
-			sliceCount = 2;
-		}
-
-		return this.descriptionLines.slice(sliceCount).join('\n');
-	}
-
-	private get descriptionLines() {
-		return this.description.split('\n');
+		return splitMessage(this.description).description || undefined;
 	}
 }
 


### PR DESCRIPTION
The changes in this commit focus on improving the handling and display of commit messages. The key changes are:

1. Introduced a new `splitMessage` utility function to split a commit message into a title and description.
2. Updated the `Commit` and `RemoteCommit` classes to use the `splitMessage` function to extract the title and description from the commit message.
3. Updated the `AIService` to use the `splitMessage` function to construct the summarized commit message.
4. Added a test suite for the `splitMessage` function to ensure it handles various commit message formats correctly.

These changes will make it easier to work with and display commit messages, as the title and description will be separated, allowing for better formatting and presentation.